### PR TITLE
Fix && and || expression chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2022-07-29
+### Fixed
+- && and || expression chaining.
+
 ## [0.6.1] - 2022-07-19
 ### Fixed
 - Fixed number parsing for exponential numbers eg. 1e10.
@@ -73,7 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/rust-playground/ksql/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/rust-playground/ksql/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/rust-playground/ksql/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/rust-playground/ksql/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/rust-playground/ksql/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/rust-playground/ksql/compare/v0.4.1...v0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ksql"
 description = "A JSON data expression lexer, parser, cli and library"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ anydate = "0.3.0"
 anyhow = "1.0.58"
 atty = "0.2.14"
 chrono = { version = "0.4.19", features = ["serde"] }
-clap = { version = "3.2.12", features = ["derive"] }
+clap = { version = "3.2.15", features = ["derive"] }
 gjson = "0.8.1"
-serde = { version = "1.0.139", features = ["derive"] }
+serde = { version = "1.0.140", features = ["derive"] }
 serde_json = "1.0.82"
 thiserror = "1.0.31"
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1675,6 +1675,11 @@ mod tests {
         let result = ex.calculate(src)?;
         assert_eq!(Value::Bool(true), result);
 
+        let expression = r#"false || (.NumberOfEmployees > "200" && .AnnualRevenue == "2000000")"#;
+        let ex = Parser::parse(expression)?;
+        let result = ex.calculate(src)?;
+        assert_eq!(Value::Bool(true), result);
+
         Ok(())
     }
 }


### PR DESCRIPTION
Fix multiple `&&` and `||` expression chaining.