### PR TITLE
Make expression Send + Sync

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -75,7 +75,7 @@ impl<'a> From<gjson::Value<'a>> for Value {
 }
 
 /// Represents a stateless parsed expression that can be applied to JSON data.
-pub trait Expression: Debug {
+pub trait Expression: Debug + Send + Sync {
     /// Will execute the parsed expression and apply it against the supplied json data.
     ///
     /// # Warnings


### PR DESCRIPTION
Expressions are already `Send + Sync`. This PR marks the trait as such so that a `Box<dyn Expression>` can be moved between threads easily (very useful when using async/await).

I needed this when making a [Stream](https://docs.rs/futures/latest/futures/stream/trait.Stream.html) that filters events based on a boolean ksql expression. Without this change, the compiler would error badly.

Signed-off-by: Matteo Joliveau <matteojoliveau@gmail.com>